### PR TITLE
Servi

### DIFF
--- a/Host/src/osimpl/input_linux.c
+++ b/Host/src/osimpl/input_linux.c
@@ -1,8 +1,6 @@
 #include <X11/extensions/XTest.h>
 #include <X11/extensions/dpms.h>
 
-#include <stdio.h>
-
 static void WakeUp(Display *display) {
 	CARD16 power_level = 0;
 	BOOL state = 0;

--- a/Host/src/osimpl/input_linux.c
+++ b/Host/src/osimpl/input_linux.c
@@ -1,6 +1,8 @@
 #include <X11/extensions/XTest.h>
 #include <X11/extensions/dpms.h>
 
+#include <stdio.h>
+
 static void WakeUp(Display *display) {
 	CARD16 power_level = 0;
 	BOOL state = 0;
@@ -37,12 +39,17 @@ static inline void SendKeycode(int keyCode) {
 
 static inline void SendKeysym(int keySym) {
 	Display *display = XOpenDisplay(NULL);
+	KeyCode kc;
 	if (display != NULL) {
-                WakeUp(display);
-
-		XTestFakeKeyEvent(display, XKeysymToKeycode(display, keySym), True, CurrentTime );
-		XTestFakeKeyEvent(display, XKeysymToKeycode(display, keySym), False, CurrentTime );
-		XFlush(display);
+		// set keycode
+		kc = XKeysymToKeycode(display, keySym);
+		// if the specified KeySym is defined
+		if (kc != 0) {
+                	WakeUp(display);
+			XTestFakeKeyEvent(display, kc, True, CurrentTime );
+			XTestFakeKeyEvent(display, kc, False, CurrentTime );
+			XFlush(display);
+		}
 		XCloseDisplay(display);
 	}
 }


### PR DESCRIPTION
Server died in case of typing chars like "čćšđ..." so I added test if the specified KeySym is defined.
With this modification, char wasn't displayed by Xserver but server-linux-amd64.out lived on.
